### PR TITLE
Refactor image publishing to use image_transport exclusively

### DIFF
--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -45,23 +45,16 @@ private:
 
   std::shared_ptr<V4l2CameraDevice> camera_;
 
-  // Publisher used for intra process comm
-  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
-  rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr info_pub_;
-
   // Publisher used for inter process comm
-  image_transport::CameraPublisher camera_transport_pub_;
+  image_transport::CameraPublisher image_pub_;
 
   /// Streaming cyclic timer
   rclcpp::TimerBase::SharedPtr streaming_timer_;
 
-  std::shared_ptr<camera_info_manager::CameraInfoManager> cinfo_;
+  std::shared_ptr<camera_info_manager::CameraInfoManager> camera_info_;
 
   std::string camera_frame_id_;
   std::string output_encoding_;
-
-  /// Streaming enabled 
-  bool streaming_enabled_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_;
 

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -33,22 +33,8 @@ namespace v4l2_camera
 V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
 : rclcpp::Node{"v4l2_camera", options},
   parameters_{get_node_parameters_interface(), get_node_topics_interface(),
-    get_node_logging_interface()},
-  streaming_enabled_{false}
+    get_node_logging_interface()}
 {
-  // Prepare publisher
-  // This should happen before registering on_set_parameters_callback,
-  // else transport plugins will fail to declare their parameters
-  auto image_topic_name = std::string(get_name()) + "/image_raw";
-  auto info_topic_name = std::string(get_name()) + "/camera_info";
-  if (options.use_intra_process_comms()) {
-    const auto qos = rclcpp::QoS(1).best_effort().durability_volatile();
-    image_pub_ = create_publisher<sensor_msgs::msg::Image>(image_topic_name, qos);
-    info_pub_ = create_publisher<sensor_msgs::msg::CameraInfo>(info_topic_name, qos);
-  } else {
-    camera_transport_pub_ = image_transport::create_camera_publisher(this, image_topic_name);
-  }
-
   parameters_.declareStaticParameters();
   parameters_.declareOutputParameters();
 
@@ -61,7 +47,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
     return;
   }
 
-  cinfo_ = std::make_shared<camera_info_manager::CameraInfoManager>(this, camera_->getCameraName());
+  camera_info_ = std::make_shared<camera_info_manager::CameraInfoManager>(this, camera_->getCameraName());
 
   parameters_.declareDeviceParameters(*camera_);
 
@@ -77,8 +63,15 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
     return;
   }
 
+  auto image_topic_name = std::string(get_name()) + "/image_raw";
+  image_pub_ = image_transport::create_camera_publisher(this, image_topic_name);
+
   std::chrono::milliseconds period(static_cast<int>(1000.0 / parameters_.getFps()));
-  streaming_timer_ = create_wall_timer(period, [this]() { capture_and_publish(); });
+  streaming_timer_ = create_wall_timer(period, [this]() {
+    if (image_pub_.getNumSubscribers() > 0) {
+      capture_and_publish();
+    }
+  });
 }
 
 V4L2Camera::~V4L2Camera()
@@ -94,8 +87,8 @@ void V4L2Camera::applyParameters()
   // Camera info parameters
   auto camera_info_url = parameters_.getCameraInfoUrl();
   if (camera_info_url != "") {
-    if (cinfo_->validateURL(camera_info_url)) {
-      cinfo_->loadCameraInfo(camera_info_url);
+    if (camera_info_->validateURL(camera_info_url)) {
+      camera_info_->loadCameraInfo(camera_info_url);
     } else {
       RCLCPP_WARN(get_logger(), "Invalid camera info URL: %s", camera_info_url.c_str());
     }
@@ -188,8 +181,8 @@ bool V4L2Camera::handleParameter(rclcpp::Parameter const & param)
     return success;
   } else if (param.get_name() == "camera_info_url") {
     auto camera_info_url = param.as_string();
-    if (cinfo_->validateURL(camera_info_url)) {
-      return cinfo_->loadCameraInfo(camera_info_url);
+    if (camera_info_->validateURL(camera_info_url)) {
+      return camera_info_->loadCameraInfo(camera_info_url);
     } else {
       RCLCPP_WARN(get_logger(), "Invalid camera info URL: %s", camera_info_url.c_str());
       return false;
@@ -248,7 +241,6 @@ bool V4L2Camera::checkCameraInfo(
 
 void V4L2Camera::capture_and_publish()
 {
-  RCLCPP_DEBUG(get_logger(), "Capture...");
   auto img = camera_->capture();
   if (img == nullptr) {
     // Failed capturing image, assume it is temporarily and continue a bit later
@@ -281,7 +273,7 @@ void V4L2Camera::capture_and_publish()
 
   cvImg->toImageMsg(*img);
 
-  auto ci = std::make_unique<sensor_msgs::msg::CameraInfo>(cinfo_->getCameraInfo());
+  auto ci = std::make_unique<sensor_msgs::msg::CameraInfo>(camera_info_->getCameraInfo());
   if (!checkCameraInfo(*img, *ci)) {
     *ci = sensor_msgs::msg::CameraInfo{};
     ci->height = img->height;
@@ -289,13 +281,7 @@ void V4L2Camera::capture_and_publish()
   }
   ci->header.stamp = stamp;
 
-  if (get_node_options().use_intra_process_comms()) {
-    RCLCPP_DEBUG_STREAM(get_logger(), "Image message address [PUBLISH]:\t" << img.get());
-    image_pub_->publish(std::move(img));
-    info_pub_->publish(std::move(ci));
-  } else {
-    camera_transport_pub_.publish(*img, *ci);
-  }
+  image_pub_.publish(*img, *ci);
 }
 
 }  // namespace v4l2_camera


### PR DESCRIPTION
- Unified all image publishing to use image_transport instead of raw publishers
- Added subscriber existence check to prevent unnecessary publishing