### PR TITLE
fix: align camera_info name with node and set CameraInfo frame_id

### DIFF
--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -64,7 +64,9 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
     parameters_.getVideoDevice(),
     parameters_.getValue<double>("capture_timeout"));
 
-  camera_info_ = std::make_shared<camera_info_manager::CameraInfoManager>(this, camera_->getCameraName());
+  // Use ROS node name (e.g. line_camera / rear_camera) so camera_info YAML camera_name matches.
+  // V4L2 card from getCameraName() may be unset before open() or non-UTF-8 garbage on some devices.
+  camera_info_ = std::make_shared<camera_info_manager::CameraInfoManager>(this, get_name());
 
   // Allow overriding QoS settings (history, depth, reliability)
   auto image_topic_name = std::string(get_name()) + "/image_raw";
@@ -353,6 +355,7 @@ void V4L2Camera::streamingTimerCallback()
     ci->width = img->width;
   }
   ci->header.stamp = stamp;
+  ci->header.frame_id = camera_frame_id_;
 
   image_pub_.publish(std::move(img), std::move(ci));
 


### PR DESCRIPTION
## Description

Use the ROS node name for `CameraInfoManager` so calibration YAML `camera_name` matches composable nodes (e.g. `rear_camera`, `line_camera`) instead of unreliable V4L2 `card` strings. Set `CameraInfo` header `frame_id` from `camera_frame_id` so it matches published `Image` messages.

## Changes

- Construct `CameraInfoManager` with `get_name()` instead of `camera_->getCameraName()`
- Assign `ci->header.frame_id = camera_frame_id_` before publish

## Testing

- Launch `v4l2_camera` composable nodes with `camera_info_url` and `camera_frame_id`; confirm no camera_name mismatch warning and `camera_info` `frame_id` matches image topic.

Made with [Cursor](https://cursor.com)