### PR TITLE
fix: use single streaming timer at configured FPS

### DIFF
--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -44,14 +44,12 @@ private:
   std::shared_ptr<V4l2CameraDevice> camera_;
   image_transport::CameraPublisher image_pub_;
   rclcpp::TimerBase::SharedPtr reconnect_timer_;
-  rclcpp::TimerBase::SharedPtr fast_streaming_timer_;
-  rclcpp::TimerBase::SharedPtr slow_streaming_timer_;
+  rclcpp::TimerBase::SharedPtr streaming_timer_;
   Parameters parameters_;
   bool device_parameters_declared_;
 
   std::shared_ptr<camera_info_manager::CameraInfoManager> camera_info_;
 
-  std::size_t subscribers_count_;
   std::string camera_frame_id_;
   std::string output_encoding_;
   int last_exposure_time_absolute_;

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -53,7 +53,6 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
   parameters_{get_node_parameters_interface(), get_node_topics_interface(),
   get_node_logging_interface()},
   device_parameters_declared_{false},
-  subscribers_count_{0},
   last_exposure_time_absolute_{0}
 {
   parameters_.declareStaticParameters();
@@ -100,7 +99,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
         }
         RCLCPP_INFO(get_logger(), "Connected to camera, start streaming");
         reconnect_timer_->cancel();
-        fast_streaming_timer_->reset();
+        streaming_timer_->reset();
         connected = true;
       } while(false);
       if (!connected) {
@@ -110,12 +109,8 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
   reconnect_timer_->cancel();
 
   auto period = std::chrono::milliseconds(static_cast<int>(1000.0 / parameters_.getFps()));
-  fast_streaming_timer_ = create_wall_timer(period, std::bind(&V4L2Camera::streamingTimerCallback, this));
-  fast_streaming_timer_->cancel();
-
-  // Streaming timer with a slow period when no subscriptions are present
-  slow_streaming_timer_ = create_wall_timer(period * 10, std::bind(&V4L2Camera::streamingTimerCallback, this));
-  slow_streaming_timer_->cancel();
+  streaming_timer_ = create_wall_timer(period, std::bind(&V4L2Camera::streamingTimerCallback, this));
+  streaming_timer_->cancel();
 
   // start connecting to camera
   reconnect_timer_->reset();
@@ -124,8 +119,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
 V4L2Camera::~V4L2Camera()
 {
   reconnect_timer_->cancel();
-  fast_streaming_timer_->cancel();
-  slow_streaming_timer_->cancel();
+  streaming_timer_->cancel();
 
   if (camera_) {
     camera_->stop();
@@ -294,30 +288,12 @@ bool V4L2Camera::checkCameraInfo(
 
 void V4L2Camera::streamingTimerCallback()
 {
-  auto previous_subscribers_count = subscribers_count_;
-  subscribers_count_ = image_pub_.getNumSubscribers();
-  if (subscribers_count_ == 0) {
-    if (previous_subscribers_count > 0) {
-      RCLCPP_INFO(get_logger(), "No subscriber, slowing down to capture");
-      fast_streaming_timer_->cancel();
-      slow_streaming_timer_->reset();
-    }
-  }
-  else {
-    if (previous_subscribers_count == 0) {
-      RCLCPP_INFO(get_logger(), "Detect subscriber, resuming to capture");
-      slow_streaming_timer_->cancel();
-      fast_streaming_timer_->reset();
-    }
-  }
-
   auto img = camera_->capture();
   if (!img) {
     RCLCPP_ERROR(get_logger(), "Failed to capture image, reconnecting...");
     camera_->stop();
     camera_->close();
-    fast_streaming_timer_->cancel();
-    slow_streaming_timer_->cancel();
+    streaming_timer_->cancel();
     reconnect_timer_->reset();
     return;
   }


### PR DESCRIPTION
## Summary

Replaces the previous fast/slow dual wall timers with a single timer that runs at the configured FPS.

## Changes

- Remove subscriber-count tracking and throttling logic that slowed capture when no image subscribers were present.
- On capture failure/reconnect paths, cancel the single streaming timer instead of coordinating two timers.

## Rationale

Simplifies timing behavior and avoids switching capture rates when subscriptions change.

Made with [Cursor](https://cursor.com)