### PR TITLE
feat: retry frame capture before reconnecting

### DIFF
--- a/include/v4l2_camera/parameters.hpp
+++ b/include/v4l2_camera/parameters.hpp
@@ -15,6 +15,8 @@
 #ifndef V4L2_CAMERA__PARAMETERS_HPP_
 #define V4L2_CAMERA__PARAMETERS_HPP_
 
+#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -79,6 +81,11 @@ public:
   double getFps() const {return getValue<double>("fps");}
   double getReconnectInterval() const {return getValue<double>("reconnect_interval");}
   double getCaptureTimeout() const {return getValue<double>("capture_timeout");}
+  int64_t getMaxConsecutiveCaptureFailures() const
+  {
+    auto v = getValue<int64_t>("max_consecutive_capture_failures");
+    return std::max<int64_t>(1, v);
+  }
   int getRotateFlag() const {return getValue<int>("rotate_flag");}
   int getFlipCode() const {return getValue<int>("flip_code");}
   bool getDynamicExposureEnabled() const {return getValue<bool>("dynamic_exposure_enabled");}

--- a/include/v4l2_camera/v4l2_camera.hpp
+++ b/include/v4l2_camera/v4l2_camera.hpp
@@ -17,6 +17,7 @@
 
 #include "v4l2_camera/v4l2_camera_device.hpp"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -53,6 +54,7 @@ private:
   std::string camera_frame_id_;
   std::string output_encoding_;
   int last_exposure_time_absolute_;
+  uint32_t consecutive_capture_failures_{0};
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_;
 

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -40,6 +40,9 @@ void Parameters::declareStaticParameters()
   declareParameter("fps", 30.0, "FPS", true);
   declareParameter("reconnect_interval", 1.0, "Connection lost retry interval", true);
   declareParameter("capture_timeout", 1.0, "Capture timeout", true);
+  declareParameter<int64_t>(
+    "max_consecutive_capture_failures", 10,
+    "Consecutive failed captures before stop, close, and reconnect", true);
   declareParameter("rotate_flag", -1, "Rotate flag", true);
   declareParameter("flip_code", -2, "Flip code", true);
   declareParameter("dynamic_exposure_enabled", false, "Dynamic exposure enabled", true);

--- a/src/v4l2_camera.cpp
+++ b/src/v4l2_camera.cpp
@@ -100,6 +100,7 @@ V4L2Camera::V4L2Camera(rclcpp::NodeOptions const & options)
         RCLCPP_INFO(get_logger(), "Connected to camera, start streaming");
         reconnect_timer_->cancel();
         streaming_timer_->reset();
+        consecutive_capture_failures_ = 0;
         connected = true;
       } while(false);
       if (!connected) {
@@ -290,13 +291,27 @@ void V4L2Camera::streamingTimerCallback()
 {
   auto img = camera_->capture();
   if (!img) {
-    RCLCPP_ERROR(get_logger(), "Failed to capture image, reconnecting...");
-    camera_->stop();
-    camera_->close();
-    streaming_timer_->cancel();
-    reconnect_timer_->reset();
+    ++consecutive_capture_failures_;
+    const auto max_fail = static_cast<uint32_t>(parameters_.getMaxConsecutiveCaptureFailures());
+    if (consecutive_capture_failures_ < max_fail) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Capture failed (%u/%u consecutive), retrying next frame",
+        consecutive_capture_failures_, max_fail);
+    } else {
+      RCLCPP_ERROR(
+        get_logger(),
+        "Failed to capture image after %u consecutive failures, reconnecting...",
+        consecutive_capture_failures_);
+      camera_->stop();
+      camera_->close();
+      streaming_timer_->cancel();
+      reconnect_timer_->reset();
+    }
     return;
   }
+
+  consecutive_capture_failures_ = 0;
 
   auto stamp = now();
   img->header.stamp = stamp;


### PR DESCRIPTION
## Summary

Adds a configurable threshold for consecutive failed `capture()` calls before tearing down the device and starting the reconnect timer. This avoids triggering a full reconnect on a single bad frame (e.g. invalid `bytesused` discarded in the V4L2 layer).

## Changes

- New read-only ROS parameter `max_consecutive_capture_failures` (default `10`), declared like other static parameters.
- `getMaxConsecutiveCaptureFailures()` clamps values below `1` to `1`.
- While under the threshold: log a warning and wait for the next frame; at threshold: same behavior as before (stop, close, reconnect timer).
- Reset failure counter on successful capture and when streaming starts after a successful reconnect.

## Configuration

Set `max_consecutive_capture_failures` in the node YAML (e.g. line/rear camera launch params) to tune sensitivity. Use `1` to restore the previous "fail once, reconnect" behavior.

## Testing

- `colcon build --packages-select v4l2_camera` passes locally.


Made with [Cursor](https://cursor.com)